### PR TITLE
Move version-detection logic to `build.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ std = []
 # not when the user invokes the code.
 always-immediate-abort = []
 
+[package.metadata.docs.rs]
+# Enable features needed to document `immediate_abort`
+features = ["std", "libc"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ rust-version = "1.54"
 # We don't use the `dep:libc` syntax because we want to support versions before Rust 1.60
 # The default-features are disabled, to avoid using the Rust stdlib.
 libc = { version = "0.2", optional = true, default-features = false }
-# Used for version-dependent code
-rustversion = "1"
+
+[build-dependencies]
+rustversion-detect = "0.1.2"
 
 [features]
 # Use the standard library abort function

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,42 @@
+use rustversion_detect::RUST_VERSION;
+
+pub fn main() {
+    // version detection
+    emit_check_cfg("has_cfg_panic", None);
+    if RUST_VERSION.is_since_minor_version(1, 60) {
+        println!("cargo:rustc-cfg=has_cfg_panic");
+    }
+    let abort_impl_name = if has_cargo_feature("std") {
+        "std"
+    } else if has_cargo_feature("libc") {
+        "libc"
+    } else {
+        "fallback"
+    };
+    emit_check_cfg("abort_impl", Some(vec!["std", "libc", "fallback"]));
+    println!("cargo:rustc-cfg=abort_impl=\"{}\"", abort_impl_name);
+    // never need to be re-run
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn has_cargo_feature(name: &str) -> bool {
+    let name = name.replace('-', "_").to_uppercase();
+    std::env::var_os(format!("CARGO_FEATURE_{name}")).is_some()
+}
+
+fn emit_check_cfg(name: &'static str, values: Option<Vec<&str>>) {
+    let mut values_spec = String::new();
+    if let Some(values) = values {
+        values_spec.push_str(", values(");
+        for (index, value) in values.into_iter().enumerate() {
+            if index > 0 {
+                values_spec.push_str(", ");
+            }
+            values_spec.push('"');
+            values_spec.push_str(value);
+            values_spec.push('"');
+        }
+        values_spec.push(')');
+    }
+    println!("cargo:rustc-check-cfg=cfg({name}{values_spec})");
+}

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,10 @@ pub fn main() {
     if RUST_VERSION.is_since_minor_version(1, 60) {
         println!("cargo:rustc-cfg=has_cfg_panic");
     }
+    emit_check_cfg("has_doc_cfg", None);
+    if RUST_VERSION.is_nightly() {
+        println!("cargo:rustc-cfg=has_doc_cfg");
+    }
     let abort_impl_name = if has_cargo_feature("std") {
         "std"
     } else if has_cargo_feature("libc") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(any(doc, feature = "std")), no_std)]
+#![cfg_attr(has_doc_cfg, feature(doc_cfg))] // doc_cfg only supported on nightly
 #![deny(dead_code)] // Don't allow missing implementations
 
 /// Abort the process, as if calling [`std::process::abort`]
@@ -77,6 +78,8 @@ pub fn abort() -> ! {
 /// In most cases (especially safe code),
 /// using the regular [`abort`] function is fine.
 #[cfg(not(abort_impl = "fallback"))]
+// NOTE: Keep doc(cfg(...)) in sync with the underlying reasons for the abort_impl
+#[cfg_attr(has_doc_cfg, doc(cfg(any(feature = "std", feature = "libc"))))]
 #[inline(always)] // immediately delegates
 pub fn immediate_abort() -> ! {
     // implicitly requires std

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,7 @@ pub fn abort() -> ! {
 /// Immediately call the platform-specific [`abort`] implementation,
 /// without invoking any other code.
 ///
-/// Unlike ,
-/// this will never use a fallback implementation that calls `panic!`.
+/// Unlike [`abort`], this will never use a fallback implementation that calls `panic!`.
 /// Instead, this function will simply not exist.
 ///
 /// In most cases (especially safe code),
@@ -160,7 +159,7 @@ fn fallback_abort() -> ! {
 
 /// A RAII guard that [aborts](`abort`) the process unless it is explicitly [defused](`AbortGuard::defuse`).
 ///
-/// This is very useful for guarenteeing a section of code will never panic,
+/// This is very useful for guaranteeing a section of code will never panic,
 /// trivially ensuring the [exception
 /// safety](https://doc.rust-lang.org/nomicon/exception-safety.html) of unsafe code.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Use `#[doc(cfg(...))]` to document when features are available.