### PR TITLE
Support Rust 1.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,7 @@ repository = "https://github.com/Techcable/libabort.rust"
 license = "Apache-2.0 OR MIT"
 # Oldest supported version because:
 # - First release of Rust 2018 was 1.31
-# - First support for rustversion::cfg!(...) was 1.39
-# - First support for #![doc = include_str!(...)] was 1.54
-#
-# I will consider compromise on last point.
-rust-version = "1.54"
+rust-version = "1.31"
 
 [dependencies]
 # Enable `feature = "libc"` to use the C standard library's `abort` function.
@@ -22,7 +18,7 @@ rust-version = "1.54"
 libc = { version = "0.2", optional = true, default-features = false }
 
 [build-dependencies]
-rustversion-detect = "0.1.2"
+rustversion-detect = "0.1.3"
 
 [features]
 # Use the standard library abort function

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # libabort [![Latest Version]][crates.io]
+
+<!-- cargo-rdme start -->
+
 An implementation of the `abort` function that works without the standard library.
 
-Provides an `AbortGuard` type to abort the process unless explicitly "defused".
+Provides an [`AbortGuard`] type to abort the process unless explicitly "defused".
 This can prevent panics from unwinding in the middle of `unsafe` code,
-which trivially makes the code [exception safe](nomicon-exception-safety).
-
-[Latest Version]: https://img.shields.io/crates/v/libabort.svg
-[crates.io]: https://crates.io/crates/libabort
+which trivially makes the code [exception safe][nomicon-exception-safety].
 
 ## Available implementations
 The library offers multiple possible implementations,
@@ -24,11 +24,23 @@ which can be controlled by using feature flags.
    then the `abort` function triggers a double-panic.
    This always triggers an abort regardless of the rust version or compiler settings.
 
-
-[`std::process::abort`]: https://doc.rust-lang.org/std/process/fn.abort.html
 [libc-abort]: https://en.cppreference.com/w/c/program/abort
 [libc-crate]: https://crates.io/crates/libc
 [nomicon-exception-safety]: https://doc.rust-lang.org/nomicon/exception-safety.html
+
+<!-- cargo-rdme end -->
+
+<!--
+   Need explicit links to type because `cargo rdme` has broken detection.
+   TODO: File an issue for this.
+-->
+[`AbortGuard`]: https://docs.rs/libabort/latest/libabort/struct.AbortGuard.html
+[`std::process::abort`]: https://doc.rust-lang.org/stable/std/process/fn.abort.html
+
+
+[Latest Version]: https://img.shields.io/crates/v/libabort.svg
+[crates.io]: https://crates.io/crates/libabort
+
 
 ## License
 Licensed under either of Apache License, Version 2.0 or MIT license at your option.

--- a/build.rs
+++ b/build.rs
@@ -83,7 +83,7 @@ fn load_cargo_cfg_var(name: &'static str) -> Vec<String> {
 
 fn has_cargo_feature(name: &str) -> bool {
     let name = name.replace('-', "_").to_uppercase();
-    std::env::var_os(format!("CARGO_FEATURE_{name}")).is_some()
+    std::env::var_os(format!("CARGO_FEATURE_{}", name)).is_some()
 }
 
 fn emit_check_cfg(name: &'static str, values: Option<Vec<&str>>) {
@@ -100,9 +100,9 @@ fn emit_check_cfg(name: &'static str, values: Option<Vec<&str>>) {
         }
         values_spec.push(')');
     }
-    println!("cargo:rustc-check-cfg=cfg({name}{values_spec})");
+    println!("cargo:rustc-check-cfg=cfg({}{})", name, values_spec);
 }
 
 fn emit_warning(msg: &dyn std::fmt::Display) {
-    println!("cargo:warning={msg}");
+    println!("cargo:warning={}", msg);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,28 @@
-#![doc = include_str!("../README.md")]
+//! An implementation of the `abort` function that works without the standard library.
+//!
+//! Provides an [`AbortGuard`] type to abort the process unless explicitly "defused".
+//! This can prevent panics from unwinding in the middle of `unsafe` code,
+//! which trivially makes the code [exception safe][nomicon-exception-safety].
+//!
+//! # Available implementations
+//! The library offers multiple possible implementations,
+//! which can be controlled by using feature flags.
+//!
+//! 1. Using the Rust standard library [`std::process::abort`] function.
+//!    This is enabled by using the "std" feature (disabled by default).
+//! 2. Using the C standard library [`abort`][libc-abort] function from the [`libc` crate][libc-crate].
+//!    This requires linking against the C standard library, but not the Rust one.
+//!    This is enabled by using the "libc" feature (disabled by default).
+//! 3. If the `panic!` implementation is known to abort instead of unwinding,
+//!    then the `abort` function simply triggers a panic.
+//!    This requires a recent version of Rust (1.60) in order to detect whether panics unwind or abort.
+//! 3. If no other implementations are available,
+//!    then the `abort` function triggers a double-panic.
+//!    This always triggers an abort regardless of the rust version or compiler settings.
+//!
+//! [libc-abort]: https://en.cppreference.com/w/c/program/abort
+//! [libc-crate]: https://crates.io/crates/libc
+//! [nomicon-exception-safety]: https://doc.rust-lang.org/nomicon/exception-safety.html
 #![cfg_attr(not(any(doc, feature = "std")), no_std)]
 #![cfg_attr(has_doc_cfg, feature(doc_cfg))] // doc_cfg only supported on nightly
 #![cfg_attr(trap_impl = "core-intrinsics", allow(internal_features))] // very stable in practice...


### PR DESCRIPTION
Use cargo rdme to sync README with crate docs, which allows us to stop using `#![doc = include_str(...)]`.
That feature is all that was keeping us on MSRV 1.59.

Bump `rustversion-detect` to [1.0.3](https://github.com/Techcable/rustversion-detect/releases/tag/v0.1.3), because that is the first version which supports Rust 1.31.