### PR TITLE
In Rust 1.81, abort by unwinding past extern "C"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,14 @@ pub fn main() {
     if RUST_VERSION.is_nightly() {
         println!("cargo:rustc-cfg=has_doc_cfg");
     }
+    emit_check_cfg("is_cabi_unwind_guarenteed_abort", None);
+    if RUST_VERSION.is_since_minor_version(1, 81) {
+        // As of Rust 1.81, unwinding past an `extern "C"` function
+        // is guarenteed to unwind
+        //
+        // Before this release, it caused undefined behavior.
+        println!("cargo:rustc-cfg=is_cabi_unwind_guarenteed_abort");
+    }
     let target_arch = {
         let mut values = load_cargo_cfg_var("target_arch");
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,10 @@
 #![cfg_attr(trap_impl = "core-intrinsics", allow(internal_features))] // very stable in practice...
 #![cfg_attr(trap_impl = "core-intrinsics", feature(core_intrinsics))]
 #![cfg_attr(trap_impl = "wasm64-intrinsic", feature(simd_wasm64))] // currently unstable
-#![deny(dead_code)] // Don't allow missing implementations
+#![deny(
+    dead_code, // Don't allow missing implementations
+    clippy::undocumented_unsafe_blocks,
+)]
 
 /// Abort the process, as if calling [`std::process::abort`]
 /// or the C standard library [`abort`](https://en.cppreference.com/w/c/program/abort) function.
@@ -117,6 +120,7 @@ pub fn immediate_abort() -> ! {
         std::process::abort();
     }
     // use standard C library abort function
+    // SAFETY: libc::abort() is safe to invoke
     #[cfg(abort_impl = "libc")]
     unsafe {
         libc::abort();


### PR DESCRIPTION
In Rust 1.81, unwinding past an extern "C" function triggers an abort.
This is preferable to a double panic because it doesn't print a backtrace.

In previous rust versions, this functionality is disabled because it
is considerd undefined behavior.


Add `#[deny(clippy::undocumented_unsafe_blocks)]`
